### PR TITLE
Fix release version crashing when loading database.

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -115,9 +115,6 @@ compose.desktop {
             packageName = "com.klemfner.whoscalling"
             packageVersion = "1.0.0"
             modules("java.sql", "java.naming")
-            windows {
-                console = true
-            }
         }
 
         buildTypes.release.proguard {


### PR DESCRIPTION
I added rule in proguard to not minify the org.sqlite packages because it removed the JDBC driver used for he sqlite database.