### PR TITLE
Fix refresh error when call type is outgoing missed

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="long_time_ago">Long Time Ago</string>
     <string name="incoming">Incoming</string>
     <string name="outgoing">Outgoing</string>
+    <string name="unknown">Unknown</string>
     <string name="missed">Missed</string>
     <string name="no_contacts">No contacts</string>
     <string name="no_call_logs">No call logs</string>
@@ -31,6 +32,7 @@
     <string name="refresh">Refresh</string>
     <string name="incoming_call">Incoming</string>
     <string name="outgoing_call">Outgoing</string>
+    <string name="unknown_call">Unknown Incoming/Outgoing</string>
     <string name="missed_incoming_call">Missed Incoming</string>
     <string name="missed_outgoing_call">Missed Outgoing</string>
     <string name="duration_label">Duration</string>

--- a/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/data/remote/PartnerCallLogDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/data/remote/PartnerCallLogDataSource.kt
@@ -4,6 +4,7 @@ import com.fleeksoft.ksoup.Ksoup
 import com.klemfner.whoscalling.domain.model.CallLog
 import com.klemfner.whoscalling.domain.model.CallType
 import com.klemfner.whoscalling.domain.model.UnauthorizedException
+import com.klemfner.whoscalling.util.Logger
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -14,10 +15,14 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 
-class PartnerCallLogsDataSource(
+class PartnerCallLogDataSource(
     private val httpClient: HttpClient,
     private val routerIp: () -> String,
 ) : CallLogRemoteDataSource {
+
+    companion object {
+        private const val TAG = "PartnerCallLogDataSource"
+    }
 
     override suspend fun getCallLogs(token: String?): List<CallLog> = withContext(Dispatchers.Default) {
         val baseUrl = "http://${routerIp()}"
@@ -59,8 +64,11 @@ class PartnerCallLogsDataSource(
             "Incoming Successful" -> CallType.INCOMING to false
             "Incoming Missed" -> CallType.INCOMING to true
             "Outgoing Successful" -> CallType.OUTGOING to false
-            "Outgoing Missed" -> CallType.OUTGOING to true
-            else -> throw IllegalArgumentException("Unknown call type: $callType")
+            "Outgoing Failed" -> CallType.OUTGOING to true
+            else -> {
+                Logger.w(TAG, "Unknown call type: $callType")
+                CallType.UNKNOWN to false
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/di/AppModule.kt
@@ -9,7 +9,7 @@ import com.klemfner.whoscalling.data.local.db.WhosCallingDatabase
 import com.klemfner.whoscalling.data.remote.AuthRemoteDataSource
 import com.klemfner.whoscalling.data.remote.CallLogRemoteDataSource
 import com.klemfner.whoscalling.data.remote.PartnerAuthenticationDataSource
-import com.klemfner.whoscalling.data.remote.PartnerCallLogsDataSource
+import com.klemfner.whoscalling.data.remote.PartnerCallLogDataSource
 import com.klemfner.whoscalling.data.remote.srp.Srp6aClient
 import com.klemfner.whoscalling.data.remote.srp.Srp6aClientImpl
 import com.klemfner.whoscalling.data.repository.AuthRepositoryImpl
@@ -44,7 +44,7 @@ val dataSourceModule = module {
     single<ContactLocalDataSource> { ContactLocalDataSourceImpl(get()) }
     single<CallLogRemoteDataSource> {
         val settingsRepo: SettingsRepository = get()
-        PartnerCallLogsDataSource(get()) { settingsRepo.currentRouterIp }
+        PartnerCallLogDataSource(get()) { settingsRepo.currentRouterIp }
     }
     single<HttpClient> { HttpClient() }
     single<Srp6aClient> { Srp6aClientImpl() }

--- a/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/domain/model/CallType.kt
+++ b/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/domain/model/CallType.kt
@@ -2,5 +2,6 @@ package com.klemfner.whoscalling.domain.model
 
 enum class CallType {
     INCOMING,
-    OUTGOING
+    OUTGOING,
+    UNKNOWN,
 }

--- a/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/calllogs/components/CallLogDetails.kt
+++ b/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/calllogs/components/CallLogDetails.kt
@@ -67,6 +67,7 @@ import whoscalling.composeapp.generated.resources.this_month
 import whoscalling.composeapp.generated.resources.this_week
 import whoscalling.composeapp.generated.resources.time_label
 import whoscalling.composeapp.generated.resources.today
+import whoscalling.composeapp.generated.resources.unknown_call
 import whoscalling.composeapp.generated.resources.yesterday
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
@@ -79,9 +80,9 @@ fun CallLogDetails(
     onAddContactClick: (String) -> Unit,
     onShowContactClick: (String) -> Unit,
     onCallLogClick: (CallLog) -> Unit,
+    modifier: Modifier = Modifier,
     defaultCountryIso: String = "",
     isRinging: Boolean = false,
-    modifier: Modifier = Modifier,
 ) {
     Scaffold(
         topBar = {
@@ -167,7 +168,7 @@ private fun CallLogHeader(
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         SelectionContainer {
-            ContactInfo(callLog = callLog, contact = contact, formattedPhone = formattedPhone)
+            ContactInfo(contact = contact, formattedPhone = formattedPhone)
         }
 
         if (contact == null) {
@@ -186,7 +187,6 @@ private fun CallLogHeader(
 
 @Composable
 private fun ContactInfo(
-    callLog: CallLog,
     contact: Contact?,
     formattedPhone: FormattedPhone,
 ) {
@@ -260,8 +260,10 @@ private fun CallTypeRow(callLog: CallLog, isRinging: Boolean = false) {
                 stringResource(Res.string.missed_outgoing_call)
             callLog.type == CallType.INCOMING ->
                 stringResource(Res.string.incoming_call)
-            else ->
+            callLog.type == CallType.OUTGOING ->
                 stringResource(Res.string.outgoing_call)
+            else ->
+                stringResource(Res.string.unknown_call)
         }
         Text(callTypeText, style = MaterialTheme.typography.bodyLarge)
     }

--- a/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/common/components/CallLogIcon.kt
+++ b/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/common/components/CallLogIcon.kt
@@ -3,6 +3,8 @@ package com.klemfner.whoscalling.ui.common.components
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.CallMade
 import androidx.compose.material.icons.automirrored.filled.CallReceived
+import androidx.compose.material.icons.automirrored.filled.Help
+import androidx.compose.material.icons.automirrored.filled.HelpOutline
 import androidx.compose.material.icons.automirrored.filled.PhoneMissed
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material3.Icon
@@ -16,12 +18,13 @@ import whoscalling.composeapp.generated.resources.Res
 import whoscalling.composeapp.generated.resources.incoming
 import whoscalling.composeapp.generated.resources.missed
 import whoscalling.composeapp.generated.resources.outgoing
+import whoscalling.composeapp.generated.resources.unknown
 
 @Composable
 fun CallLogIcon(
     callLog: CallLog,
-    isRinging: Boolean = false,
     modifier: Modifier = Modifier,
+    isRinging: Boolean = false,
 ) {
     if (isRinging) {
         Icon(
@@ -48,6 +51,12 @@ fun CallLogIcon(
             CallType.OUTGOING -> Icon(
                 Icons.AutoMirrored.Filled.CallMade,
                 contentDescription = stringResource(Res.string.outgoing),
+                tint = MaterialTheme.colorScheme.secondary,
+                modifier = modifier,
+            )
+            CallType.UNKNOWN -> Icon(
+                Icons.AutoMirrored.Filled.HelpOutline,
+                contentDescription = stringResource(Res.string.unknown),
                 tint = MaterialTheme.colorScheme.secondary,
                 modifier = modifier,
             )

--- a/composeApp/src/commonTest/kotlin/com/klemfner/whoscalling/data/repository/CallLogRepositoryImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/klemfner/whoscalling/data/repository/CallLogRepositoryImplTest.kt
@@ -218,6 +218,20 @@ class CallLogRepositoryImplTest {
     }
 
     @Test
+    fun ringingCall_emitsNullWhenLastCallIsUnknown() = runTest {
+        fakeCurrentTimeMillis = 100_000L
+        val logs = listOf(
+            CallLog("1", "+1234567890", CallType.UNKNOWN, false, 80_000L, 60L)
+        )
+        localDataSource.saveCallLogs(logs)
+
+        repository.ringingCall.test {
+            assertNull(awaitItem())
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
     fun ringingCall_emitsNullWhenLastCallIsNotMissed() = runTest {
         fakeCurrentTimeMillis = 100_000L
         val logs = listOf(


### PR DESCRIPTION
When Partner shows that the call is missed outgoing, it shows the text "Outgoing Failed" and not "Outgoing Missed". This made the refresh to fail.

I also made it possible now to get unknown call types so it won't fail in such case.