### PR TITLE
Update call logs items to show time instead of duration

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/calllogs/components/CallLogDetails.kt
+++ b/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/calllogs/components/CallLogDetails.kt
@@ -43,7 +43,7 @@ import com.klemfner.whoscalling.ui.common.components.FormattedPhoneText
 import com.klemfner.whoscalling.ui.common.utils.TimePeriod
 import com.klemfner.whoscalling.ui.common.utils.formatDuration
 import com.klemfner.whoscalling.ui.common.utils.formatShortDate
-import com.klemfner.whoscalling.ui.common.utils.formatTimestamp
+import com.klemfner.whoscalling.ui.common.utils.formatShortTime
 import com.klemfner.whoscalling.ui.common.utils.getTimePeriod
 import com.klemfner.whoscalling.ui.common.components.ContactCallLogItem
 import com.klemfner.whoscalling.util.FormattedPhone
@@ -281,7 +281,7 @@ private fun TimeRow(callLog: CallLog) {
             modifier = Modifier.size(20.dp),
         )
         Text(
-            "${formatShortDate(callLog.timestamp)} ${formatTimestamp(callLog.timestamp)}",
+            "${formatShortDate(callLog.timestamp)} ${formatShortTime(callLog.timestamp)}",
             style = MaterialTheme.typography.bodyMedium,
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/calllogs/components/CallLogListItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/calllogs/components/CallLogListItem.kt
@@ -20,7 +20,7 @@ import com.klemfner.whoscalling.ui.common.components.FormattedPhoneText
 import com.klemfner.whoscalling.ui.common.utils.TimePeriod
 import com.klemfner.whoscalling.ui.common.utils.formatDuration
 import com.klemfner.whoscalling.ui.common.utils.formatShortDate
-import com.klemfner.whoscalling.ui.common.utils.formatTimestamp
+import com.klemfner.whoscalling.ui.common.utils.formatShortTime
 import com.klemfner.whoscalling.ui.common.utils.getTimePeriod
 import com.klemfner.whoscalling.util.formatPhoneForDisplay
 
@@ -33,12 +33,6 @@ fun CallLogListItem(
     modifier: Modifier = Modifier,
     defaultCountryIso: String = "",
 ) {
-    val period = getTimePeriod(callLog.timestamp)
-    val displayTime = if (period == TimePeriod.TODAY || period == TimePeriod.YESTERDAY) {
-        formatTimestamp(callLog.timestamp)
-    } else {
-        formatShortDate(callLog.timestamp)
-    }
     val formattedPhone = remember(callLog.phoneNumber, defaultCountryIso) {
         formatPhoneForDisplay(callLog.phoneNumber, defaultCountryIso)
     }
@@ -48,36 +42,23 @@ fun CallLogListItem(
             CallLogIcon(callLog)
         },
         headlineContent = {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                if (contact != null) {
-                    Text(
-                        contact.name,
-                        modifier = Modifier.weight(1f, fill = false),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                } else {
-                    FormattedPhoneText(
-                        formattedPhone = formattedPhone,
-                        modifier = Modifier.weight(1f, fill = false),
-                        style = MaterialTheme.typography.bodyLarge,
-                        overflowWithEllipsis = true,
-                    )
-                }
-
+            if (contact != null) {
                 Text(
-                    "(${formatDuration(callLog.duration)})",
-                    style = MaterialTheme.typography.bodyLarge,
+                    contact.name,
                     maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            } else {
+                FormattedPhoneText(
+                    formattedPhone = formattedPhone,
+                    style = MaterialTheme.typography.bodyLarge,
+                    overflowWithEllipsis = true,
                 )
             }
         },
         trailingContent = {
             Text(
-                displayTime,
+                "${formatShortDate(callLog.timestamp)} ${formatShortTime(callLog.timestamp)}",
                 style = MaterialTheme.typography.bodySmall,
             )
         },

--- a/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/common/components/ContactCallLogItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/common/components/ContactCallLogItem.kt
@@ -11,33 +11,26 @@ import com.klemfner.whoscalling.domain.model.CallLog
 import com.klemfner.whoscalling.ui.common.utils.TimePeriod
 import com.klemfner.whoscalling.ui.common.utils.formatDuration
 import com.klemfner.whoscalling.ui.common.utils.formatShortDate
-import com.klemfner.whoscalling.ui.common.utils.formatTimestamp
+import com.klemfner.whoscalling.ui.common.utils.formatShortTime
 import com.klemfner.whoscalling.ui.common.utils.getTimePeriod
 
 @Composable
 fun ContactCallLogItem(
     callLog: CallLog,
+    modifier: Modifier = Modifier,
     isSelected: Boolean = false,
     onClick: (() -> Unit)? = null,
-    modifier: Modifier = Modifier,
 ) {
-    val period = getTimePeriod(callLog.timestamp)
-    val displayTime = if (period == TimePeriod.TODAY || period == TimePeriod.YESTERDAY) {
-        formatTimestamp(callLog.timestamp)
-    } else {
-        formatShortDate(callLog.timestamp)
-    }
-
     ListItem(
         leadingContent = {
             CallLogIcon(callLog)
         },
         headlineContent = {
-            Text(formatDuration(callLog.duration))
+            Text(formatShortTime(callLog.timestamp))
         },
         trailingContent = {
             Text(
-                displayTime,
+                formatShortDate(callLog.timestamp),
                 style = MaterialTheme.typography.bodySmall,
             )
         },

--- a/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/common/utils/FormatUtils.kt
+++ b/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/common/utils/FormatUtils.kt
@@ -17,7 +17,7 @@ fun formatDuration(durationSeconds: Long): String {
     }
 }
 
-fun formatTimestamp(timestampMillis: Long): String {
+fun formatShortTime(timestampMillis: Long): String {
     val tz = TimeZone.currentSystemDefault()
     val dateTime = Instant.fromEpochMilliseconds(timestampMillis).toLocalDateTime(tz)
     val hour = dateTime.hour.toString().padStart(2, '0')

--- a/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/settings/DebugLogsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/settings/DebugLogsScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.klemfner.whoscalling.ui.common.utils.PlatformBackHandler
 import com.klemfner.whoscalling.ui.common.utils.formatShortDate
-import com.klemfner.whoscalling.ui.common.utils.formatTimestamp
+import com.klemfner.whoscalling.ui.common.utils.formatShortTime
 import com.klemfner.whoscalling.util.LogEntry
 import com.klemfner.whoscalling.util.LogLevel
 import com.klemfner.whoscalling.util.Logger
@@ -136,7 +136,7 @@ private fun LogEntryCard(
                 )
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
-                        text = "${formatShortDate(entry.timestamp)} ${formatTimestamp(entry.timestamp)}",
+                        text = "${formatShortDate(entry.timestamp)} ${formatShortTime(entry.timestamp)}",
                         style = MaterialTheme.typography.labelSmall,
                         color = Color.Black.copy(alpha = 0.7f),
                     )

--- a/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/user/UserScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/klemfner/whoscalling/ui/user/UserScreen.kt
@@ -52,7 +52,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.klemfner.whoscalling.ui.common.utils.formatShortDate
-import com.klemfner.whoscalling.ui.common.utils.formatTimestamp
+import com.klemfner.whoscalling.ui.common.utils.formatShortTime
 import com.klemfner.whoscalling.ui.navigation.LocalNavigator
 import com.klemfner.whoscalling.ui.navigation.NavAction
 import com.klemfner.whoscalling.ui.navigation.NavigationTab
@@ -254,7 +254,7 @@ private fun UserProfile(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(
-                text = "${formatShortDate(user.loginTime)} ${formatTimestamp(user.loginTime)}",
+                text = "${formatShortDate(user.loginTime)} ${formatShortTime(user.loginTime)}",
                 style = MaterialTheme.typography.bodyMedium,
             )
         }

--- a/composeApp/src/commonTest/kotlin/com/klemfner/whoscalling/ui/common/utils/FormatUtilsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/klemfner/whoscalling/ui/common/utils/FormatUtilsTest.kt
@@ -37,7 +37,7 @@ class FormatUtilsTest {
 
     @Test
     fun formatTimestampFormatsCorrectly() {
-        val result = formatTimestamp(1705328400000L)
+        val result = formatShortTime(1705328400000L)
         assertEquals(5, result.length)
         assertEquals(':', result[2])
     }


### PR DESCRIPTION
Who cares about the call duration? It shouldn't be the main thing visible.